### PR TITLE
A library harness to run an analysis for shared libraries

### DIFF
--- a/src/org/jakstab/Main.java
+++ b/src/org/jakstab/Main.java
@@ -140,8 +140,17 @@ public class Main {
 		}
 
 		// Add surrounding "%DF := 1; call entrypoint; halt;" 
-		program.installHarness(Options.heuristicEntryPoints.getValue() ? new HeuristicHarness() : new DefaultHarness());
-
+		if (Options.heuristicEntryPoints.getValue()) {
+			logger.info("Using heuristic harness");
+			program.installHarness(new HeuristicHarness());
+		} else if (Options.analyseDll.getValue()) {
+			logger.info("Using library harness");
+			program.installHarness(new LibraryHarness());
+		} else {
+			logger.info("Using default harness");
+			program.installHarness(new DefaultHarness());
+		}
+		
 		int slashIdx = baseFileName.lastIndexOf('\\');
 		if (slashIdx < 0) slashIdx = baseFileName.lastIndexOf('/');
 		if (slashIdx < 0) slashIdx = -1;

--- a/src/org/jakstab/Options.java
+++ b/src/org/jakstab/Options.java
@@ -94,6 +94,7 @@ public class Options {
 	public static JOption<Boolean> initHeapToBot = JOption.create("bot-heap", "Initialize heap cells to BOT to force strong updates.");
 	public static JOption<Boolean> summarizeRep = JOption.create("summarize-rep", "Use summarizing transformer for string instructions.");
 	public static JOption<Boolean> basicBlocks = JOption.create("basicblocks", "Build CFA from basic-blocks instead of single statements.");
+	public static JOption<Boolean> analyseDll = JOption.create("dll", "Run analysis for all exports of a DLL.");
 	public static JOption<Integer> simplifyVCFG = JOption.create("simplifyVCFG", "l", 1, "In VPC-CFG reconstruction, simplify the reconstructed graph using (0) nothing (1) DCE (2) DCE + Expression Substitution");
 	public static JOption<Integer> verbosity = JOption.create("v", "level", 3, "Set verbosity to value. Default is 3.");
 	public static JOption<Integer> timeout = JOption.create("timeout", "t", -1, "Set timeout in seconds for the analysis.");

--- a/src/org/jakstab/Program.java
+++ b/src/org/jakstab/Program.java
@@ -561,4 +561,19 @@ public final class Program {
 		}
 		return res;
 	}
+	
+	public LinkedList<BranchInstruction> getIndirectBranches() {
+		LinkedList<BranchInstruction> indirectBranches = new LinkedList<BranchInstruction>();
+		for (Map.Entry<AbsoluteAddress, Instruction> entry : assemblyMap.entrySet()) {
+			Instruction instr = entry.getValue();
+			
+			if (instr instanceof BranchInstruction) {
+				BranchInstruction branch = (BranchInstruction)instr;
+				if (branch.isIndirect()) {
+					indirectBranches.add(branch);
+				}
+			}
+		}
+		return indirectBranches;
+	}
 }

--- a/src/org/jakstab/cfa/ControlFlowGraph.java
+++ b/src/org/jakstab/cfa/ControlFlowGraph.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.jakstab.Options;
 import org.jakstab.Program;
 import org.jakstab.rtl.statements.BasicBlock;
 import org.jakstab.rtl.statements.RTLAssume;
@@ -377,6 +378,8 @@ public class ControlFlowGraph {
 			if (getInDegree(l) == 0) {
 				assert entryPoint == null : "Graph has multiple entry points: " + entryPoint + " and " + l; 
 				entryPoint = l;
+				if (Options.analyseDll.getValue())
+					break;
 			}
 		}
 		assert entryPoint != null : "No entry point found! First statement in cycle?";

--- a/src/org/jakstab/loader/LibraryHarness.java
+++ b/src/org/jakstab/loader/LibraryHarness.java
@@ -1,0 +1,149 @@
+/*
+ * Harness to call every function exported by a library. First function is DllMain
+ */
+package org.jakstab.loader;
+
+import java.util.LinkedList;
+
+import org.jakstab.Program;
+import org.jakstab.analysis.MemoryRegion;
+import org.jakstab.asm.AbsoluteAddress;
+import org.jakstab.cfa.RTLLabel;
+import org.jakstab.rtl.expressions.ExpressionFactory;
+import org.jakstab.rtl.expressions.RTLVariable;
+import org.jakstab.rtl.statements.ILBuilder;
+import org.jakstab.rtl.statements.RTLAlloc;
+import org.jakstab.rtl.statements.RTLGoto;
+import org.jakstab.rtl.statements.RTLHalt;
+import org.jakstab.rtl.statements.RTLStatement;
+import org.jakstab.rtl.statements.RTLVariableAssignment;
+import org.jakstab.rtl.statements.StatementSequence;
+import org.jakstab.util.Logger;
+
+public class LibraryHarness implements Harness {
+
+	private LinkedList<AbsoluteAddress> entryPoints;
+	
+	private RTLVariable esp = Program.getProgram().getArchitecture().stackPointer();
+
+	private static int CALL_INSTR_DISTANCE = 1;
+
+	private static Logger logger = Logger.getLogger(LibraryHarness.class);
+	
+	private AbsoluteAddress lastAddress;
+
+	
+	public LibraryHarness() {
+		entryPoints = new LinkedList<AbsoluteAddress>();
+		
+		Program program = Program.getProgram();
+		
+		// add all exports
+		for (ExportedSymbol es: program.getSymbols()) {
+			entryPoints.add(es.getAddress());
+		}
+		
+		lastAddress = new AbsoluteAddress(0);
+		
+		logger.info("DLL analysis unlocked, adding exports");
+	}
+	
+	@Override
+	public void install(Program program) {
+		StatementSequence seq = new StatementSequence();
+		seq.addLast(new RTLVariableAssignment(1, ExpressionFactory.createVariable("%DF", 1), ExpressionFactory.FALSE));
+		seq.addLast(new RTLAlloc(esp, MemoryRegion.STACK.toString()));
+		
+		// Allocate TLS depending on OS type
+		if (program.getTargetOS() == Program.TargetOS.WINDOWS)
+			seq.addLast(new RTLAlloc(ExpressionFactory.createVariable("%fs", 16), "FS"));
+		else if (program.getTargetOS() == Program.TargetOS.LINUX)
+			seq.addLast(new RTLAlloc(ExpressionFactory.createVariable("%gs", 16), "GS"));
+		
+		// push the return address for the first goto
+		AbsoluteAddress returnAddress = new AbsoluteAddress(prologueAddress.getValue() + CALL_INSTR_DISTANCE);
+		ILBuilder.getInstance().createPush(returnAddress.toNumericConstant(), seq);
+		// jump to the entry point
+		seq.addLast(new RTLGoto(program.getStart().getAddress().toNumericConstant(), RTLGoto.Type.CALL));
+
+		// add the sequence for DllMain
+		putSequence(program, seq, prologueAddress);
+		
+		// now, create calls to all exports
+		for (AbsoluteAddress export: entryPoints) {
+			// start a new instruction sequence
+			seq = new StatementSequence();
+			
+			AbsoluteAddress currentAddress = returnAddress;
+			lastAddress = currentAddress;
+
+			// the new return address is either the following call or the epilogue
+			returnAddress = entryPoints.peekLast() != export ? new AbsoluteAddress(currentAddress.getValue() + CALL_INSTR_DISTANCE) : epilogueAddress;
+			
+			// clear registers
+			for (RTLVariable v : program.getArchitecture().getRegisters()) {
+				if (!v.equals(esp)) {
+					clearReg(seq, v);
+				}
+			}
+			
+			// reset esp
+			clearReg(seq, esp);
+			seq.addLast(new RTLAlloc(esp, MemoryRegion.STACK.toString()));
+			
+			// push new return address
+			ILBuilder.getInstance().createPush(returnAddress.toNumericConstant(), seq);
+			//push32(seq, returnAddress.toNumericConstant());
+			// add the call
+			seq.addLast(new RTLGoto(export.toNumericConstant(), RTLGoto.Type.CALL));
+			
+			//logger.info("Adding call to " + export + " at " + currentAddress);
+			putSequence(program, seq, currentAddress);
+		}
+		
+		// set the prologue as the entry address of the program
+		program.setEntryAddress(prologueAddress);
+		
+		// epilogue with halt statement
+		seq = new StatementSequence();
+		seq.addLast(new RTLHalt());
+		putSequence(program, seq, epilogueAddress);
+	}
+
+	private void clearReg(StatementSequence seq, RTLVariable v) {
+		seq.addLast(new RTLVariableAssignment(v.getBitWidth(), v, ExpressionFactory.nondet(v.getBitWidth())));
+	}
+	
+	private void putSequence(Program program, StatementSequence seq, AbsoluteAddress address) {
+		int rtlId = 0;
+		for (RTLStatement stmt : seq) {
+			stmt.setLabel(address, rtlId++);
+			stmt.setNextLabel(new RTLLabel(address, rtlId));
+		}
+		seq.getLast().setNextLabel(null);
+
+		// add stub statements to program
+		for (RTLStatement s : seq) {
+			program.putStatement(s);
+		}
+	}
+	
+	@Override
+	public boolean contains(AbsoluteAddress a) {
+		return a.getValue() >= PROLOGUE_BASE && a.getValue() <= lastAddress.getValue();
+	}
+
+	@Override
+	public AbsoluteAddress getFallthroughAddress(AbsoluteAddress a) {
+		if (a.getValue() >= PROLOGUE_BASE && a.getValue() < lastAddress.getValue()) {
+			logger.info("Providing fall through address");
+			return new AbsoluteAddress(a.getValue() + CALL_INSTR_DISTANCE);
+		} else if (a.equals(lastAddress)) {
+			logger.info("Providing last fall through address (epilogue)");
+			return epilogueAddress;
+		} else { 
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
This code adds a new command-line option "--dll" that uses the library harness for analysis. The library harness enumerates all entry points of a shared library as fall-through addresses. It is built similar to the heuristic harness.